### PR TITLE
chore: run jobs once at startup

### DIFF
--- a/src/Modules/Currencies/Infra/Jobs/CurrenciesJob.ts
+++ b/src/Modules/Currencies/Infra/Jobs/CurrenciesJob.ts
@@ -13,6 +13,11 @@ class CurrenciesJob {
 
     updateJob.start();
   }
+
+  public once(): void {
+    const updateCurrencies = container.resolve(UpdateCurrenciesService);
+    updateCurrencies.execute();
+  }
 }
 
 export default CurrenciesJob;

--- a/src/Shared/Infra/Http/index.ts
+++ b/src/Shared/Infra/Http/index.ts
@@ -23,6 +23,7 @@ const rateLimiter = new RateLimiter();
 
 typeORM.run().then(() => {
   jobs.run();
+  jobs.once();
 });
 
 app.use(cors());

--- a/src/Shared/Infra/Jobs/index.ts
+++ b/src/Shared/Infra/Jobs/index.ts
@@ -1,10 +1,14 @@
 import CurrenciesJob from 'Modules/Currencies/Infra/Jobs/CurrenciesJob';
 
 class Jobs {
-  public run(): void {
-    const currenciesJob = new CurrenciesJob();
+  private currenciesJob = new CurrenciesJob();
 
-    currenciesJob.update();
+  public run(): void {
+    this.currenciesJob.update();
+  }
+
+  public once(): void {
+    this.currenciesJob.once();
   }
 }
 


### PR DESCRIPTION
I noticed that in order to get currencies updated I need to wait until scheduled job is dispatched. For this reason I added the method `Jobs.once` which is called at startups.

Hope it could be helpful!