### PR TITLE
Mark a currency as favorite

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ If [Wellets](https://wellets.ondaniel.com.br/) currently does not have a certain
 | METHOD | PATH                   | SHORT DESCRIPTION                           |
 | ------ | ---------------------- | ------------------------------------------- |
 | GET    | /currencies            | Index native and user custom currencies     |
+| PUT    | /currencies/:id        | Set preference for the currency             |
 | GET    | /currencies/rate       | Show currency rate based on other currency  |
 | GET    | /currencies/custom     | Index user custom currencies                |
 | POST   | /currencies/custom     | Create a custom currency                    |

--- a/src/Modules/Currencies/DTOs/ICreateCurrencyDTO.ts
+++ b/src/Modules/Currencies/DTOs/ICreateCurrencyDTO.ts
@@ -3,6 +3,7 @@ interface ICreateCurrencyDTO {
   alias: string;
   format: string;
   dollar_rate: number;
+  favorite?: boolean;
   user_id?: string;
 }
 

--- a/src/Modules/Currencies/Infra/Http/Controllers/CurrenciesController.ts
+++ b/src/Modules/Currencies/Infra/Http/Controllers/CurrenciesController.ts
@@ -2,6 +2,7 @@ import { Request, Response, NextFunction } from 'express';
 import { container } from 'tsyringe';
 
 import IndexCurrenciesService from 'Modules/Currencies/Services/IndexCurrenciesService';
+import CreateOrUpdateCurrencyPreferenceService from 'Modules/CurrencyPreferences/Services/CreateOrUpdateCurrencyPreferenceService';
 
 class CurrenciesController {
   public async index(
@@ -10,13 +11,40 @@ class CurrenciesController {
     _: NextFunction,
   ): Promise<Response> {
     const { user } = request;
+    const { sortBy } = request.query;
     const id = user && user.id ? user.id : '';
 
     const indexCurrencies = container.resolve(IndexCurrenciesService);
 
-    const currencies = await indexCurrencies.execute(id);
+    const currencies = await indexCurrencies.execute(
+      id,
+      (typeof sortBy === 'string' && sortBy) || undefined,
+    );
 
     return response.json(currencies);
+  }
+
+  public async update(
+    request: Request,
+    response: Response,
+    _: NextFunction,
+  ): Promise<Response> {
+    const { user } = request;
+    const { id } = request.params;
+
+    const { favorite } = request.body;
+
+    const createOrUpdateCurrencyPreference = container.resolve(
+      CreateOrUpdateCurrencyPreferenceService,
+    );
+
+    const currencyPreference = await createOrUpdateCurrencyPreference.execute({
+      user_id: user.id,
+      currency_id: id,
+      favorite,
+    });
+
+    return response.json(currencyPreference);
   }
 }
 

--- a/src/Modules/Currencies/Infra/Http/Controllers/CustomCurrenciesController.ts
+++ b/src/Modules/Currencies/Infra/Http/Controllers/CustomCurrenciesController.ts
@@ -50,7 +50,7 @@ class CustomCurrenciesController {
     const currency_preference = await createCurrencyPreference.execute({
       user_id: id,
       currency_id: currency.id,
-      favorite,
+      favorite: !!favorite,
     });
 
     currency.favorite = currency_preference.favorite;
@@ -84,7 +84,7 @@ class CustomCurrenciesController {
     const currency_preference = await updateCurrencyPreference.execute({
       user_id: user.id,
       currency_id: currency.id,
-      favorite,
+      favorite: !!favorite,
     });
 
     currency.favorite = currency_preference.favorite;

--- a/src/Modules/Currencies/Infra/Http/Controllers/CustomCurrenciesController.ts
+++ b/src/Modules/Currencies/Infra/Http/Controllers/CustomCurrenciesController.ts
@@ -5,6 +5,8 @@ import IndexCustomCurrenciesService from 'Modules/Currencies/Services/IndexCusto
 import CreateCustomCurrencyService from 'Modules/Currencies/Services/CreateCustomCurrencyService';
 import UpdateCustomCurrencyService from 'Modules/Currencies/Services/UpdateCustomCurrencyService';
 import DeleteCustomCurrencyService from 'Modules/Currencies/Services/DeleteCustomCurrencyService';
+import CreateCurrencyPreferenceService from 'Modules/CurrencyPreferences/Services/CreateCurrencyPreferenceService';
+import UpdateCurrencyPreferenceService from 'Modules/CurrencyPreferences/Services/UpdateCurrencyPreferenceService';
 
 class CustomCurrenciesController {
   public async index(
@@ -30,9 +32,12 @@ class CustomCurrenciesController {
     _: NextFunction,
   ): Promise<Response> {
     const { id } = request.user;
-    const { acronym, alias, dollar_rate, format } = request.body;
+    const { acronym, alias, dollar_rate, format, favorite } = request.body;
 
     const createCustomCurrency = container.resolve(CreateCustomCurrencyService);
+    const createCurrencyPreference = container.resolve(
+      CreateCurrencyPreferenceService,
+    );
 
     const currency = await createCustomCurrency.execute({
       user_id: id,
@@ -41,6 +46,14 @@ class CustomCurrenciesController {
       dollar_rate,
       format,
     });
+
+    const currency_preference = await createCurrencyPreference.execute({
+      user_id: id,
+      currency_id: currency.id,
+      favorite,
+    });
+
+    currency.favorite = currency_preference.favorite;
 
     return response.json(currency);
   }
@@ -52,9 +65,12 @@ class CustomCurrenciesController {
   ): Promise<Response> {
     const { user } = request;
     const { id } = request.params;
-    const { acronym, alias, dollar_rate, format } = request.body;
+    const { acronym, alias, dollar_rate, format, favorite } = request.body;
 
     const updateCustomCurrency = container.resolve(UpdateCustomCurrencyService);
+    const updateCurrencyPreference = container.resolve(
+      UpdateCurrencyPreferenceService,
+    );
 
     const currency = await updateCustomCurrency.execute({
       user_id: user.id,
@@ -64,6 +80,14 @@ class CustomCurrenciesController {
       format,
       id,
     });
+
+    const currency_preference = await updateCurrencyPreference.execute({
+      user_id: user.id,
+      currency_id: currency.id,
+      favorite,
+    });
+
+    currency.favorite = currency_preference.favorite;
 
     return response.json(currency);
   }

--- a/src/Modules/Currencies/Infra/Http/Routes/Currencies.routes.ts
+++ b/src/Modules/Currencies/Infra/Http/Routes/Currencies.routes.ts
@@ -1,3 +1,4 @@
+import { celebrate, Joi, Segments } from 'celebrate';
 import { Router } from 'express';
 
 import AuthController from 'Shared/Containers/AuthProvider/Controllers/AuthController';
@@ -10,5 +11,17 @@ const currenciesController = new CurrenciesController();
 // Private routes
 currenciesRoutes.use(authController.on);
 currenciesRoutes.get('/', currenciesController.index);
+currenciesRoutes.put(
+  '/:id',
+  celebrate({
+    [Segments.BODY]: {
+      favorite: Joi.boolean().required(),
+    },
+    [Segments.PARAMS]: {
+      id: Joi.string().uuid().required(),
+    },
+  }),
+  currenciesController.update,
+);
 
 export default currenciesRoutes;

--- a/src/Modules/Currencies/Infra/Http/Routes/CustomCurrencies.routes.ts
+++ b/src/Modules/Currencies/Infra/Http/Routes/CustomCurrencies.routes.ts
@@ -19,6 +19,7 @@ customCurrenciesRoutes.post(
       alias: Joi.string().required(),
       dollar_rate: Joi.number().positive().required(),
       format: Joi.string().required(),
+      favorite: Joi.boolean(),
     },
   }),
   customCurrenciesController.create,
@@ -31,6 +32,7 @@ customCurrenciesRoutes.put(
       alias: Joi.string().required(),
       dollar_rate: Joi.number().positive().required(),
       format: Joi.string().required(),
+      favorite: Joi.boolean(),
     },
     [Segments.PARAMS]: {
       id: Joi.string().uuid().required(),

--- a/src/Modules/Currencies/Infra/TypeORM/Entities/Currency.ts
+++ b/src/Modules/Currencies/Infra/TypeORM/Entities/Currency.ts
@@ -11,6 +11,8 @@ import {
 
 import Wallet from 'Modules/Wallets/Infra/TypeORM/Entities/Wallet';
 import User from 'Modules/Users/Infra/TypeORM/Entities/User';
+import CurrencyPreference from 'Modules/CurrencyPreferences/Infra/TypeORM/Entities/CurrencyPreference';
+import { VirtualColumn } from 'Shared/Infra/TypeORM/Decorators/VirtualColumn';
 
 @Entity('currencies')
 class Currency {
@@ -38,12 +40,21 @@ class Currency {
   @Column('uuid')
   user_id?: string;
 
+  @VirtualColumn()
+  favorite: boolean;
+
   @ManyToOne(() => User, user => user.custom_currencies)
   @JoinColumn({ name: 'user_id' })
   user?: User;
 
   @OneToMany(() => Wallet, wallet => wallet.currency)
   wallets: Wallet[];
+
+  @OneToMany(
+    () => CurrencyPreference,
+    currency_preference => currency_preference.currency,
+  )
+  user_preferences: CurrencyPreference[];
 }
 
 export default Currency;

--- a/src/Modules/Currencies/Infra/TypeORM/Repositories/CurrenciesRepository.ts
+++ b/src/Modules/Currencies/Infra/TypeORM/Repositories/CurrenciesRepository.ts
@@ -54,7 +54,7 @@ class CurrenciesRepository implements ICurrenciesRepository {
       where = get_natives ? [{ user_id }, { user_id: IsNull() }] : { user_id };
     }
 
-    return this.selectQuery().where(where).orderBy(orderBy).getMany();
+    return this.selectQuery(user_id).where(where).orderBy(orderBy).getMany();
   }
 
   public async findByAcronym(
@@ -84,7 +84,7 @@ class CurrenciesRepository implements ICurrenciesRepository {
     await this.ormRepository.delete(id);
   }
 
-  private selectQuery() {
+  private selectQuery(user_id?: string) {
     return this.ormRepository
       .createQueryBuilder('currency')
       .addSelect(
@@ -94,7 +94,8 @@ class CurrenciesRepository implements ICurrenciesRepository {
       .leftJoin(
         'currency.user_preferences',
         'preference',
-        'currency.id = preference.currency_id AND preference.user_id = currency.user_id',
+        'currency.id = preference.currency_id AND preference.user_id = :user_id',
+        { user_id },
       );
   }
 }

--- a/src/Modules/Currencies/Repositories/ICurrenciesRepository.ts
+++ b/src/Modules/Currencies/Repositories/ICurrenciesRepository.ts
@@ -9,7 +9,11 @@ interface ICurrenciesRepository {
   ): Promise<Currency | undefined>;
   save(currency: Currency): Promise<Currency>;
   findById(id: string): Promise<Currency | undefined>;
-  find(user_id?: string, get_natives?: boolean): Promise<Currency[]>;
+  find(
+    user_id?: string,
+    get_natives?: boolean,
+    sort_by_favorite?: boolean,
+  ): Promise<Currency[]>;
   delete(id: string): Promise<void>;
 }
 

--- a/src/Modules/Currencies/Services/IndexCurrenciesService.ts
+++ b/src/Modules/Currencies/Services/IndexCurrenciesService.ts
@@ -10,7 +10,7 @@ class IndexCurrenciesService {
   ) {}
 
   public async execute(user_id?: string): Promise<Currency[]> {
-    return this.currenciesRepository.find(user_id, true);
+    return this.currenciesRepository.find(user_id, true, true);
   }
 }
 

--- a/src/Modules/Currencies/Services/IndexCurrenciesService.ts
+++ b/src/Modules/Currencies/Services/IndexCurrenciesService.ts
@@ -9,8 +9,10 @@ class IndexCurrenciesService {
     private currenciesRepository: ICurrenciesRepository,
   ) {}
 
-  public async execute(user_id?: string): Promise<Currency[]> {
-    return this.currenciesRepository.find(user_id, true, true);
+  public async execute(user_id?: string, sortBy?: string): Promise<Currency[]> {
+    const sort_by_favorite = !sortBy || sortBy === 'favorite';
+
+    return this.currenciesRepository.find(user_id, true, sort_by_favorite);
   }
 }
 

--- a/src/Modules/Currencies/Services/IndexCustomCurrenciesService.ts
+++ b/src/Modules/Currencies/Services/IndexCustomCurrenciesService.ts
@@ -10,7 +10,7 @@ class IndexCustomCurrenciesService {
   ) {}
 
   public async execute(user_id?: string): Promise<Currency[]> {
-    return this.currenciesRepository.find(user_id);
+    return this.currenciesRepository.find(user_id, false, false);
   }
 }
 

--- a/src/Modules/CurrencyPreferences/Containers/index.ts
+++ b/src/Modules/CurrencyPreferences/Containers/index.ts
@@ -1,0 +1,9 @@
+import { container } from 'tsyringe';
+
+import ICurrencyPreferencesRepository from '../Repositories/ICurrencyPreferencesRepository';
+import CurrencyPreferencesRepository from '../Infra/TypeORM/Repositories/CurrencyPreferencesRepository';
+
+container.registerSingleton<ICurrencyPreferencesRepository>(
+  'CurrencyPreferencesRepository',
+  CurrencyPreferencesRepository,
+);

--- a/src/Modules/CurrencyPreferences/DTOs/ICreateCurrencyPreferenceDTO.ts
+++ b/src/Modules/CurrencyPreferences/DTOs/ICreateCurrencyPreferenceDTO.ts
@@ -1,0 +1,7 @@
+interface ICreateCurrencyPreferenceDTO {
+  favorite: boolean;
+  user_id: string;
+  currency_id: string;
+}
+
+export default ICreateCurrencyPreferenceDTO;

--- a/src/Modules/CurrencyPreferences/DTOs/ICreateOrUpdateCurrencyPreferenceDTO.ts
+++ b/src/Modules/CurrencyPreferences/DTOs/ICreateOrUpdateCurrencyPreferenceDTO.ts
@@ -1,0 +1,7 @@
+interface ICreateOrUpdateCurrencyPreferenceDTO {
+  currency_id: string;
+  user_id: string;
+  favorite: boolean;
+}
+
+export default ICreateOrUpdateCurrencyPreferenceDTO;

--- a/src/Modules/CurrencyPreferences/DTOs/IUpdateCurrencyPreferenceDTO.ts
+++ b/src/Modules/CurrencyPreferences/DTOs/IUpdateCurrencyPreferenceDTO.ts
@@ -1,0 +1,5 @@
+import ICreateCurrencyPreferenceDTO from './ICreateCurrencyPreferenceDTO';
+
+type IUpdateCurrencyPreferenceDTO = ICreateCurrencyPreferenceDTO;
+
+export default IUpdateCurrencyPreferenceDTO;

--- a/src/Modules/CurrencyPreferences/Infra/TypeORM/Entities/CurrencyPreference.ts
+++ b/src/Modules/CurrencyPreferences/Infra/TypeORM/Entities/CurrencyPreference.ts
@@ -1,0 +1,43 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+
+import Currency from 'Modules/Currencies/Infra/TypeORM/Entities/Currency';
+import User from 'Modules/Users/Infra/TypeORM/Entities/User';
+
+@Entity('currency_preferences')
+class CurrencyPreference {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  favorite: boolean;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+
+  @Column('uuid')
+  user_id: string;
+
+  @Column('uuid')
+  currency_id: string;
+
+  @ManyToOne(() => User, user => user.currency_preferences)
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+
+  @ManyToOne(() => Currency, currency => currency.user_preferences)
+  @JoinColumn({ name: 'currency_id' })
+  currency: Currency;
+}
+
+export default CurrencyPreference;

--- a/src/Modules/CurrencyPreferences/Infra/TypeORM/Repositories/CurrencyPreferencesRepository.ts
+++ b/src/Modules/CurrencyPreferences/Infra/TypeORM/Repositories/CurrencyPreferencesRepository.ts
@@ -1,0 +1,46 @@
+import { Repository, getRepository } from 'typeorm';
+
+import CurrencyPreference from '../Entities/CurrencyPreference';
+import ICreateCurrencyPreferenceDTO from '../../../DTOs/ICreateCurrencyPreferenceDTO';
+import ICurrencyPreferencesRepository from '../../../Repositories/ICurrencyPreferencesRepository';
+
+class CurrencyPreferencesRepository implements ICurrencyPreferencesRepository {
+  private ormRepository: Repository<CurrencyPreference>;
+
+  constructor() {
+    this.ormRepository = getRepository(CurrencyPreference);
+  }
+
+  public async create(
+    data: ICreateCurrencyPreferenceDTO,
+  ): Promise<CurrencyPreference> {
+    const currency = this.ormRepository.create(data);
+
+    await this.ormRepository.save(currency);
+
+    return currency;
+  }
+
+  public async save(currency: CurrencyPreference): Promise<CurrencyPreference> {
+    await this.ormRepository.save(currency);
+
+    return currency;
+  }
+
+  public async findById(id: string): Promise<CurrencyPreference | undefined> {
+    return this.ormRepository.findOne(id);
+  }
+
+  public async find(
+    user_id: string,
+    currency_id: string,
+  ): Promise<CurrencyPreference | undefined> {
+    return this.ormRepository.findOne({ where: { user_id, currency_id } });
+  }
+
+  public async delete(id: string): Promise<void> {
+    await this.ormRepository.delete(id);
+  }
+}
+
+export default CurrencyPreferencesRepository;

--- a/src/Modules/CurrencyPreferences/Repositories/ICurrencyPreferencesRepository.ts
+++ b/src/Modules/CurrencyPreferences/Repositories/ICurrencyPreferencesRepository.ts
@@ -1,0 +1,15 @@
+import CurrencyPreference from '../Infra/TypeORM/Entities/CurrencyPreference';
+import ICreateCurrencyPreferenceDTO from '../DTOs/ICreateCurrencyPreferenceDTO';
+
+interface ICurrencyPreferencesRepository {
+  create(data: ICreateCurrencyPreferenceDTO): Promise<CurrencyPreference>;
+  save(currency: CurrencyPreference): Promise<CurrencyPreference>;
+  findById(id: string): Promise<CurrencyPreference | undefined>;
+  find(
+    user_id: string,
+    currency_id: string,
+  ): Promise<CurrencyPreference | undefined>;
+  delete(id: string): Promise<void>;
+}
+
+export default ICurrencyPreferencesRepository;

--- a/src/Modules/CurrencyPreferences/Services/CreateCurrencyPreferenceService.ts
+++ b/src/Modules/CurrencyPreferences/Services/CreateCurrencyPreferenceService.ts
@@ -1,0 +1,31 @@
+import { injectable, inject } from 'tsyringe';
+
+import AppError from 'Shared/Errors/AppError';
+import ICreateCurrencyPreferenceDTO from '../DTOs/ICreateCurrencyPreferenceDTO';
+import CurrencyPreference from '../Infra/TypeORM/Entities/CurrencyPreference';
+import ICurrencyPreferencesRepository from '../Repositories/ICurrencyPreferencesRepository';
+
+@injectable()
+class CreateCurrencyPreferenceService {
+  constructor(
+    @inject('CurrencyPreferencesRepository')
+    private currencyPreferencesRepository: ICurrencyPreferencesRepository,
+  ) {}
+
+  public async execute(
+    data: ICreateCurrencyPreferenceDTO,
+  ): Promise<CurrencyPreference> {
+    const exists = await this.currencyPreferencesRepository.find(
+      data.user_id,
+      data.currency_id,
+    );
+
+    if (exists) {
+      throw new AppError('Cannot create another preference on this currency!');
+    }
+
+    return this.currencyPreferencesRepository.create(data);
+  }
+}
+
+export default CreateCurrencyPreferenceService;

--- a/src/Modules/CurrencyPreferences/Services/CreateOrUpdateCurrencyPreferenceService.ts
+++ b/src/Modules/CurrencyPreferences/Services/CreateOrUpdateCurrencyPreferenceService.ts
@@ -1,0 +1,47 @@
+import { inject, injectable, container } from 'tsyringe';
+
+import CurrencyPreference from '../Infra/TypeORM/Entities/CurrencyPreference';
+import ICreateOrUpdateCurrencyPreferenceDTO from '../DTOs/ICreateOrUpdateCurrencyPreferenceDTO';
+import UpdateCurrencyPreferenceService from './UpdateCurrencyPreferenceService';
+import CreateCurrencyPreferenceService from './CreateCurrencyPreferenceService';
+import ICurrencyPreferencesRepository from '../Repositories/ICurrencyPreferencesRepository';
+
+@injectable()
+class CreateOrUpdateCurrencyPreferenceService {
+  constructor(
+    @inject('CurrencyPreferencesRepository')
+    private currencyPreferencesRepository: ICurrencyPreferencesRepository,
+  ) {}
+
+  public async execute(
+    data: ICreateOrUpdateCurrencyPreferenceDTO,
+  ): Promise<CurrencyPreference> {
+    const createCurrencyPreference = container.resolve(
+      CreateCurrencyPreferenceService,
+    );
+    const updateCurrencyPreference = container.resolve(
+      UpdateCurrencyPreferenceService,
+    );
+
+    const exists = await this.currencyPreferencesRepository.find(
+      data.user_id,
+      data.currency_id,
+    );
+
+    if (exists) {
+      return updateCurrencyPreference.execute({
+        user_id: exists.user_id,
+        currency_id: exists.currency_id,
+        favorite: data.favorite,
+      });
+    }
+
+    return createCurrencyPreference.execute({
+      user_id: data.user_id,
+      currency_id: data.currency_id,
+      favorite: data.favorite,
+    });
+  }
+}
+
+export default CreateOrUpdateCurrencyPreferenceService;

--- a/src/Modules/CurrencyPreferences/Services/UpdateCurrencyPreferenceService.ts
+++ b/src/Modules/CurrencyPreferences/Services/UpdateCurrencyPreferenceService.ts
@@ -1,0 +1,44 @@
+import { inject, injectable } from 'tsyringe';
+
+import AppError from 'Shared/Errors/AppError';
+import CurrencyPreference from '../Infra/TypeORM/Entities/CurrencyPreference';
+import ICurrencyPreferencesRepository from '../Repositories/ICurrencyPreferencesRepository';
+import IUpdateCurrencyPreferenceDTO from '../DTOs/IUpdateCurrencyPreferenceDTO';
+
+@injectable()
+class UpdateCurrencyPreferenceService {
+  constructor(
+    @inject('CurrencyPreferencesRepository')
+    private currencyPreferencesRepository: ICurrencyPreferencesRepository,
+  ) {}
+
+  public async execute({
+    user_id,
+    currency_id,
+    ...data
+  }: IUpdateCurrencyPreferenceDTO): Promise<CurrencyPreference> {
+    const currencyPreference = await this.currencyPreferencesRepository.find(
+      user_id,
+      currency_id,
+    );
+
+    if (!currencyPreference) {
+      throw new AppError('This currency preference does not exist!', 404);
+    }
+
+    if (currencyPreference.user_id !== user_id) {
+      throw new AppError(
+        'You does not have permission to manage this currency preference!',
+        403,
+      );
+    }
+
+    Object.assign(currencyPreference, data);
+
+    await this.currencyPreferencesRepository.save(currencyPreference);
+
+    return currencyPreference;
+  }
+}
+
+export default UpdateCurrencyPreferenceService;

--- a/src/Modules/Users/Infra/TypeORM/Entities/User.ts
+++ b/src/Modules/Users/Infra/TypeORM/Entities/User.ts
@@ -10,6 +10,7 @@ import { Exclude } from 'class-transformer';
 
 import Wallet from 'Modules/Wallets/Infra/TypeORM/Entities/Wallet';
 import Currency from 'Modules/Currencies/Infra/TypeORM/Entities/Currency';
+import CurrencyPreference from 'Modules/CurrencyPreferences/Infra/TypeORM/Entities/CurrencyPreference';
 
 @Entity('users')
 class User {
@@ -37,6 +38,12 @@ class User {
 
   @OneToMany(() => Currency, currency => currency.user)
   custom_currencies: Currency[];
+
+  @OneToMany(
+    () => CurrencyPreference,
+    currency_preference => currency_preference.user,
+  )
+  currency_preferences: CurrencyPreference[];
 }
 
 export default User;

--- a/src/Shared/Containers/index.ts
+++ b/src/Shared/Containers/index.ts
@@ -1,6 +1,7 @@
 // Modules containers
 import 'Modules/Transfers/Containers';
 import 'Modules/Currencies/Containers';
+import 'Modules/CurrencyPreferences/Containers';
 import 'Modules/Users/Containers';
 import 'Modules/Transactions/Containers';
 import 'Modules/Wallets/Containers';

--- a/src/Shared/Infra/TypeORM/Decorators/VirtualColumn.ts
+++ b/src/Shared/Infra/TypeORM/Decorators/VirtualColumn.ts
@@ -1,0 +1,13 @@
+import 'reflect-metadata';
+
+export const VIRTUAL_COLUMN_KEY = Symbol('VIRTUAL_COLUMN_KEY');
+
+export function VirtualColumn(name?: string): PropertyDecorator {
+  return (target, propertyKey) => {
+    const metaInfo = Reflect.getMetadata(VIRTUAL_COLUMN_KEY, target) || {};
+
+    metaInfo[propertyKey] = name ?? propertyKey;
+
+    Reflect.defineMetadata(VIRTUAL_COLUMN_KEY, metaInfo, target);
+  };
+}

--- a/src/Shared/Infra/TypeORM/Migrations/1630608556415-CreateTableCurrencyPreferences.ts
+++ b/src/Shared/Infra/TypeORM/Migrations/1630608556415-CreateTableCurrencyPreferences.ts
@@ -1,0 +1,83 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableForeignKey,
+} from 'typeorm';
+
+export default class CreateTableCurrencyPreferences1630608556415
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'currency_preferences',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'favorite',
+            type: 'boolean',
+            isNullable: false,
+            default: false,
+          },
+          {
+            name: 'user_id',
+            type: 'uuid',
+            isNullable: false,
+          },
+          {
+            name: 'currency_id',
+            type: 'uuid',
+            isNullable: false,
+          },
+          {
+            name: 'created_at',
+            type: 'timestamp',
+            default: 'now()',
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamp',
+            default: 'now()',
+          },
+        ],
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'currency_preferences',
+      new TableForeignKey({
+        name: 'user_id',
+        columnNames: ['user_id'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'users',
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE',
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'currency_preferences',
+      new TableForeignKey({
+        name: 'currency_id',
+        columnNames: ['currency_id'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'currencies',
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropForeignKey('currency_preferences', 'currency_id');
+    await queryRunner.dropForeignKey('currency_preferences', 'user_id');
+    await queryRunner.dropTable('currency_preferences');
+  }
+}

--- a/src/Shared/Infra/TypeORM/index.ts
+++ b/src/Shared/Infra/TypeORM/index.ts
@@ -1,5 +1,6 @@
 import { createConnection } from 'typeorm';
 
+import './polyfill';
 import log from '../../Helpers/log';
 
 class TypeORM {

--- a/src/Shared/Infra/TypeORM/polyfill.ts
+++ b/src/Shared/Infra/TypeORM/polyfill.ts
@@ -1,0 +1,46 @@
+/* eslint-disable func-names */
+/* eslint-disable no-shadow */
+/* eslint-disable no-param-reassign */
+
+import 'reflect-metadata';
+import { SelectQueryBuilder } from 'typeorm';
+import { VIRTUAL_COLUMN_KEY } from './Decorators/VirtualColumn';
+
+declare module 'typeorm' {
+  interface SelectQueryBuilder<Entity> {
+    getMany(this: SelectQueryBuilder<Entity>): Promise<Entity[] | undefined>;
+    getOne(this: SelectQueryBuilder<Entity>): Promise<Entity | undefined>;
+  }
+}
+
+SelectQueryBuilder.prototype.getMany = async function () {
+  const { entities, raw } = await this.getRawAndEntities();
+
+  const items = entities.map((entitiy, index) => {
+    const metaInfo = Reflect.getMetadata(VIRTUAL_COLUMN_KEY, entitiy) ?? {};
+    const item = raw[index];
+
+    for (const [propertyKey, name] of Object.entries<string>(metaInfo)) {
+      entitiy[propertyKey] = item[name];
+    }
+
+    return entitiy;
+  });
+
+  return [...items];
+};
+
+SelectQueryBuilder.prototype.getOne = async function () {
+  const { entities, raw } = await this.getRawAndEntities();
+  if (!entities || !entities.length) {
+    return undefined;
+  }
+
+  const metaInfo = Reflect.getMetadata(VIRTUAL_COLUMN_KEY, entities[0]) ?? {};
+
+  for (const [propertyKey, name] of Object.entries<string>(metaInfo)) {
+    entities[0][propertyKey] = raw[0][name];
+  }
+
+  return entities[0];
+};


### PR DESCRIPTION
This feature allow the user to mark a currency as favorite. It works both with custom and non-custom currencies.

The "favorite" preference is mainly used for sorting purposes: favorite currencies come before non-favorite currencies. Both favorite currencies and non-favorite currencies are then sorted by acronym.

**Types**

The `Currency` entity now includes a boolean property, namely `favorite`.

**Migrations**

We added a pivot table between currencies and users.

**Endpoints**

* `PUT /currencies/:id` (added), modifies the preference on a currency

```
curl --location --request PUT 'http://localhost:3333/currencies/e4035906-167d-44e4-b5d1-948d9c07f5a3' \
--header $TOKEN \
--header 'Content-Type: application/json' \
--data-raw '{
    "favorite": false
}'
```

* `POST /currencies/custom` (updated), we can mark currency as favorite on create (favorite key is not mandatory)

```
curl --location --request POST 'http://localhost:3333/currencies/custom' \
--header $TOKEN \
--header 'Content-Type: application/json' \
--data-raw '{
    "acronym": "FOO",
    "alias": "foo",
    "dollar_rate": 1,
    "format": "$ 00.00",
    "favorite": true
}'
``` 

* `PUT /currencies/custom/:id` (updated), same as `POST /currencies/custom` but for currency updates

* `GET /currencies` (updated), now accepts `sortBy` query parameter which can be used to specify which type of sorting we want to use. Allowed values are `acronym`, `favorite`. By default it sorts by favorite.

```
curl --location --request GET 'http://localhost:3333/currencies?sortBy=favorite' \
--header $TOKEN
```