### PR TITLE
Add base currency

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ If [Wellets](https://wellets.ondaniel.com.br/) currently does not have a certain
 | POST   | /users                 | User sign up                                |
 | POST   | /users/sessions        | User sign in                                |
 | DELETE | /users/sessions        | User sign out                               |
+| GET    | /users/settings        | Get user settings                           |
+| POST   | /users/settings        | Create user settings                        |
+| PUT    | /users/settings        | Update user settings                        |
 | GET    | /wallets               | Index user wallets                          |
 | POST   | /wallets               | Create a wallet                             |
 | DELETE | /wallets               | Delete a wallet                             |

--- a/src/Modules/Users/Containers/index.ts
+++ b/src/Modules/Users/Containers/index.ts
@@ -1,9 +1,17 @@
 import { container } from 'tsyringe';
 
 import IUsersRepository from '../Repositories/IUsersRepository';
+import IUserSettingsRepository from '../Repositories/IUserSettingsRepository';
+
 import UsersRepository from '../Infra/TypeORM/Repositories/UsersRepository';
+import UserSettingsRepository from '../Infra/TypeORM/Repositories/UserSettingsRepository';
 
 container.registerSingleton<IUsersRepository>(
   'UsersRepository',
   UsersRepository,
+);
+
+container.registerSingleton<IUserSettingsRepository>(
+  'UserSettingsRepository',
+  UserSettingsRepository,
 );

--- a/src/Modules/Users/DTOs/ICreateUserSettingsDTO.ts
+++ b/src/Modules/Users/DTOs/ICreateUserSettingsDTO.ts
@@ -1,0 +1,6 @@
+interface ICreateUserSettingsDTO {
+  user_id: string;
+  currency_id?: string;
+}
+
+export default ICreateUserSettingsDTO;

--- a/src/Modules/Users/DTOs/IFindByUserIdDTO.ts
+++ b/src/Modules/Users/DTOs/IFindByUserIdDTO.ts
@@ -1,0 +1,5 @@
+interface IFindByUserIdDTO {
+  user_id: string;
+}
+
+export default IFindByUserIdDTO;

--- a/src/Modules/Users/DTOs/IUpdateUserSettingsDTO.ts
+++ b/src/Modules/Users/DTOs/IUpdateUserSettingsDTO.ts
@@ -1,0 +1,6 @@
+interface IUpdateUserSettingsDTO {
+  user_id: string;
+  currency_id: string;
+}
+
+export default IUpdateUserSettingsDTO;

--- a/src/Modules/Users/Infra/Http/Controllers/UserSettingsController.ts
+++ b/src/Modules/Users/Infra/Http/Controllers/UserSettingsController.ts
@@ -1,0 +1,62 @@
+import { Request, Response, NextFunction } from 'express';
+import { container } from 'tsyringe';
+
+import ShowUserSettingsService from 'Modules/Users/Services/ShowUserSettingsService';
+import UpdateUserSettingsService from 'Modules/Users/Services/UpdateUserSettingsService';
+import CreateUserSettingsService from 'Modules/Users/Services/CreateUserSettingsService';
+
+class UserSettingsController {
+  public async show(
+    request: Request,
+    response: Response,
+    _: NextFunction,
+  ): Promise<Response> {
+    const { id } = request.user;
+
+    const showUserSettings = container.resolve(ShowUserSettingsService);
+
+    const userSettings = await showUserSettings.execute({
+      user_id: id,
+    });
+
+    return response.json(userSettings);
+  }
+
+  public async create(
+    request: Request,
+    response: Response,
+    _: NextFunction,
+  ): Promise<Response> {
+    const { user } = request;
+    const { currency_id } = request.body;
+
+    const createUserSettings = container.resolve(CreateUserSettingsService);
+
+    const userSettings = await createUserSettings.execute({
+      user_id: user.id,
+      currency_id,
+    });
+
+    return response.json(userSettings);
+  }
+
+  public async update(
+    request: Request,
+    response: Response,
+    _: NextFunction,
+  ): Promise<Response> {
+    const { user } = request;
+    const { currency_id } = request.body;
+
+    const updateUserSettings = container.resolve(UpdateUserSettingsService);
+
+    const userSettings = await updateUserSettings.execute({
+      user_id: user.id,
+      currency_id,
+    });
+
+    return response.json(userSettings);
+  }
+}
+
+export default UserSettingsController;

--- a/src/Modules/Users/Infra/Http/Routes/Settings.routes.ts
+++ b/src/Modules/Users/Infra/Http/Routes/Settings.routes.ts
@@ -1,0 +1,32 @@
+import { celebrate, Joi, Segments } from 'celebrate';
+import { Router } from 'express';
+
+import AuthController from 'Shared/Containers/AuthProvider/Controllers/AuthController';
+import UserSettingsController from '../Controllers/UserSettingsController';
+
+const routes = Router();
+const authController = new AuthController();
+const userSettingsController = new UserSettingsController();
+
+routes.use(authController.on);
+routes.get('/', userSettingsController.show);
+routes.post(
+  '/',
+  celebrate({
+    [Segments.BODY]: {
+      currency_id: Joi.string().uuid(),
+    },
+  }),
+  userSettingsController.create,
+);
+routes.put(
+  '/',
+  celebrate({
+    [Segments.BODY]: {
+      currency_id: Joi.string().uuid().required(),
+    },
+  }),
+  userSettingsController.update,
+);
+
+export default routes;

--- a/src/Modules/Users/Infra/Http/Routes/index.routes.ts
+++ b/src/Modules/Users/Infra/Http/Routes/index.routes.ts
@@ -1,11 +1,13 @@
 import { Router } from 'express';
 
 import sessionsRoutes from './Sessions.routes';
+import settingsRoutes from './Settings.routes';
 import usersRoutes from './Users.routes';
 
 const routes = Router();
 
 routes.use('/sessions', sessionsRoutes);
+routes.use('/settings', settingsRoutes);
 routes.use('/', usersRoutes);
 
 export default routes;

--- a/src/Modules/Users/Infra/TypeORM/Entities/UserSettings.ts
+++ b/src/Modules/Users/Infra/TypeORM/Entities/UserSettings.ts
@@ -1,0 +1,41 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  OneToOne,
+} from 'typeorm';
+
+import User from 'Modules/Users/Infra/TypeORM/Entities/User';
+import Currency from 'Modules/Currencies/Infra/TypeORM/Entities/Currency';
+
+@Entity('user_settings')
+class UserSettings {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column('uuid', { unique: true })
+  user_id: string;
+
+  @Column('uuid')
+  currency_id: string;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+
+  @OneToOne(() => User)
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+
+  @ManyToOne(() => Currency)
+  @JoinColumn({ name: 'currency_id' })
+  currency: Currency;
+}
+
+export default UserSettings;

--- a/src/Modules/Users/Infra/TypeORM/Repositories/UserSettingsRepository.ts
+++ b/src/Modules/Users/Infra/TypeORM/Repositories/UserSettingsRepository.ts
@@ -1,0 +1,49 @@
+import { EntityRepository, getRepository, Repository } from 'typeorm';
+
+import IFindByUserIdDTO from '../../../DTOs/IFindByUserIdDTO';
+import ICreateUserSettingsDTO from '../../../DTOs/ICreateUserSettingsDTO';
+import IUserSettingsRepository from '../../../Repositories/IUserSettingsRepository';
+import UserSettings from '../Entities/UserSettings';
+
+@EntityRepository(UserSettings)
+class UserSettingsRepository implements IUserSettingsRepository {
+  private ormRepository: Repository<UserSettings>;
+
+  constructor() {
+    this.ormRepository = getRepository(UserSettings);
+  }
+
+  public async findById(id: string): Promise<UserSettings | undefined> {
+    const userSettings = await this.ormRepository.findOne(id);
+
+    return userSettings;
+  }
+
+  public async findByUserId({
+    user_id,
+  }: IFindByUserIdDTO): Promise<UserSettings | undefined> {
+    const userSettings = await this.ormRepository.findOne({
+      where: {
+        user_id,
+      },
+    });
+
+    return userSettings;
+  }
+
+  public async create(data: ICreateUserSettingsDTO): Promise<UserSettings> {
+    const userSettings = this.ormRepository.create(data);
+
+    await this.ormRepository.save(userSettings);
+
+    return userSettings;
+  }
+
+  public async save(userSettings: UserSettings): Promise<UserSettings> {
+    await this.ormRepository.save(userSettings);
+
+    return userSettings;
+  }
+}
+
+export default UserSettingsRepository;

--- a/src/Modules/Users/Repositories/IUserSettingsRepository.ts
+++ b/src/Modules/Users/Repositories/IUserSettingsRepository.ts
@@ -1,0 +1,12 @@
+import UserSettings from '../Infra/TypeORM/Entities/UserSettings';
+import IFindByUserIdDTO from '../DTOs/IFindByUserIdDTO';
+import ICreateUserSettingsDTO from '../DTOs/ICreateUserSettingsDTO';
+
+interface IUserSettingsRepository {
+  findById(id: string): Promise<UserSettings | undefined>;
+  findByUserId(data: IFindByUserIdDTO): Promise<UserSettings | undefined>;
+  create(data: ICreateUserSettingsDTO): Promise<UserSettings>;
+  save(userSettings: UserSettings): Promise<UserSettings>;
+}
+
+export default IUserSettingsRepository;

--- a/src/Modules/Users/Services/AuthenticateUserService.ts
+++ b/src/Modules/Users/Services/AuthenticateUserService.ts
@@ -1,4 +1,4 @@
-import { injectable, inject } from 'tsyringe';
+import { injectable, inject, container } from 'tsyringe';
 
 import AppError from 'Shared/Errors/AppError';
 import IHashProvider from 'Shared/Containers/HashProvider/Models/IHashProvider';
@@ -6,6 +6,7 @@ import IAuthProvider from 'Shared/Containers/AuthProvider/Models/IAuthProvider';
 import User from '../Infra/TypeORM/Entities/User';
 import ICreateUserDTO from '../DTOs/ICreateUserDTO';
 import IUsersRepository from '../Repositories/IUsersRepository';
+import CreateUserSettingsService from './CreateUserSettingsService';
 
 @injectable()
 class AuthenticateUserService {
@@ -43,6 +44,9 @@ class AuthenticateUserService {
     Object.assign(user, { token });
 
     await this.usersRepository.save(user);
+
+    const createUserSettings = container.resolve(CreateUserSettingsService);
+    await createUserSettings.execute({ user_id: user.id });
 
     return user;
   }

--- a/src/Modules/Users/Services/CreateUserService.ts
+++ b/src/Modules/Users/Services/CreateUserService.ts
@@ -1,10 +1,11 @@
-import { injectable, inject } from 'tsyringe';
+import { injectable, inject, container } from 'tsyringe';
 
 import IHashProvider from 'Shared/Containers/HashProvider/Models/IHashProvider';
 import AppError from 'Shared/Errors/AppError';
 import User from '../Infra/TypeORM/Entities/User';
 import ICreateUserDTO from '../DTOs/ICreateUserDTO';
 import IUsersRepository from '../Repositories/IUsersRepository';
+import CreateUserSettingsService from './CreateUserSettingsService';
 
 @injectable()
 class CreateUserService {
@@ -31,6 +32,9 @@ class CreateUserService {
       email: parsedEmail,
       password: hashedPassword,
     });
+
+    const createUserSettings = container.resolve(CreateUserSettingsService);
+    await createUserSettings.execute({ user_id: user.id });
 
     return user;
   }

--- a/src/Modules/Users/Services/CreateUserSettingsService.ts
+++ b/src/Modules/Users/Services/CreateUserSettingsService.ts
@@ -1,0 +1,51 @@
+import { inject, injectable } from 'tsyringe';
+
+import AppError from 'Shared/Errors/AppError';
+import ICurrenciesRepository from 'Modules/Currencies/Repositories/ICurrenciesRepository';
+import Currency from 'Modules/Currencies/Infra/TypeORM/Entities/Currency';
+import UserSettings from '../Infra/TypeORM/Entities/UserSettings';
+import ICreateUserSettingsDTO from '../DTOs/ICreateUserSettingsDTO';
+import IUserSettingsRepository from '../Repositories/IUserSettingsRepository';
+
+@injectable()
+class CreateUserSettingsService {
+  constructor(
+    @inject('UserSettingsRepository')
+    private userSettingsRepository: IUserSettingsRepository,
+
+    @inject('CurrenciesRepository')
+    private currenciesRepository: ICurrenciesRepository,
+  ) {}
+
+  public async execute({
+    user_id,
+    currency_id,
+  }: ICreateUserSettingsDTO): Promise<UserSettings> {
+    const exists = await this.userSettingsRepository.findByUserId({ user_id });
+
+    if (exists) {
+      return exists;
+    }
+
+    let currency: Currency;
+
+    if (currency_id) {
+      currency = await this.currenciesRepository.findById(currency_id);
+    } else {
+      currency = await this.currenciesRepository.findByAcronym('USD');
+    }
+
+    if (!currency) {
+      throw new AppError('Cannot find USD currency!', 404);
+    }
+
+    const userSettings = await this.userSettingsRepository.create({
+      user_id,
+      currency_id: currency.id,
+    });
+
+    return userSettings;
+  }
+}
+
+export default CreateUserSettingsService;

--- a/src/Modules/Users/Services/ShowUserSettingsService.ts
+++ b/src/Modules/Users/Services/ShowUserSettingsService.ts
@@ -1,0 +1,31 @@
+import AppError from 'Shared/Errors/AppError';
+import { inject, injectable } from 'tsyringe';
+
+import UserSettings from '../Infra/TypeORM/Entities/UserSettings';
+import IUserSettingsRepository from '../Repositories/IUserSettingsRepository';
+
+interface IRequest {
+  user_id: string;
+}
+
+@injectable()
+class ShowUserSettingsService {
+  constructor(
+    @inject('UserSettingsRepository')
+    private userSettingsRepository: IUserSettingsRepository,
+  ) {}
+
+  public async execute({ user_id }: IRequest): Promise<UserSettings> {
+    const userSettings = await this.userSettingsRepository.findByUserId({
+      user_id,
+    });
+
+    if (!userSettings) {
+      throw new AppError('User settings not found!', 404);
+    }
+
+    return userSettings;
+  }
+}
+
+export default ShowUserSettingsService;

--- a/src/Modules/Users/Services/UpdateUserSettingsService.ts
+++ b/src/Modules/Users/Services/UpdateUserSettingsService.ts
@@ -1,0 +1,46 @@
+import { inject, injectable } from 'tsyringe';
+
+import AppError from 'Shared/Errors/AppError';
+import ICurrenciesRepository from 'Modules/Currencies/Repositories/ICurrenciesRepository';
+import UserSettings from '../Infra/TypeORM/Entities/UserSettings';
+import IUpdateUserSettingsDTO from '../DTOs/IUpdateUserSettingsDTO';
+import IUserSettingsRepository from '../Repositories/IUserSettingsRepository';
+
+@injectable()
+class UpdateUserSettingsService {
+  constructor(
+    @inject('UserSettingsRepository')
+    private userSettingsRepository: IUserSettingsRepository,
+
+    @inject('CurrenciesRepository')
+    private currenciesRepository: ICurrenciesRepository,
+  ) {}
+
+  public async execute({
+    user_id,
+    currency_id,
+  }: IUpdateUserSettingsDTO): Promise<UserSettings> {
+    const userSettings = await this.userSettingsRepository.findByUserId({
+      user_id,
+    });
+
+    if (!userSettings) {
+      throw new AppError('Cannot find user settings!', 404);
+    }
+
+    const currency = await this.currenciesRepository.findById(currency_id);
+
+    if (!currency) {
+      throw new AppError('Cannot find currency!', 404);
+    }
+
+    userSettings.currency_id = currency_id;
+    userSettings.currency = currency;
+
+    await this.userSettingsRepository.save(userSettings);
+
+    return userSettings;
+  }
+}
+
+export default UpdateUserSettingsService;

--- a/src/Shared/Infra/TypeORM/Migrations/1635713928520-CreateTableUserSettings.ts
+++ b/src/Shared/Infra/TypeORM/Migrations/1635713928520-CreateTableUserSettings.ts
@@ -1,0 +1,78 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableForeignKey,
+} from 'typeorm';
+
+export default class CreateTableUserSettings1635713928520
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'user_settings',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'user_id',
+            type: 'uuid',
+            isNullable: false,
+            isUnique: true,
+          },
+          {
+            name: 'currency_id',
+            type: 'uuid',
+            isNullable: false,
+          },
+          {
+            name: 'created_at',
+            type: 'timestamp',
+            default: 'now()',
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamp',
+            default: 'now()',
+          },
+        ],
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'user_settings',
+      new TableForeignKey({
+        name: 'user_id',
+        columnNames: ['user_id'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'users',
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE',
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'user_settings',
+      new TableForeignKey({
+        name: 'currency_id',
+        columnNames: ['currency_id'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'currencies',
+        onDelete: 'SET NULL',
+        onUpdate: 'CASCADE',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropForeignKey('user_settings', 'currency_id');
+    await queryRunner.dropForeignKey('user_settings', 'user_id');
+    await queryRunner.dropTable('user_settings');
+  }
+}


### PR DESCRIPTION
# Base Currency

Base currency will be used in the frontend to display total balance automatically selecting preferred user currency.

**Endpoints**

User settings can be created, updated or shown (not deleted) with `/users/settings` endpoint by using POST, PUT or GET HTTP methods.

**Model**

```
{
  id: string;
  user_id: string;
  currency_id: string;
  // and, created_at and updated_at fields
}
```

User settings are saved in `user_settings` table which is in relation one-to-one with `users` table, i.e., every user has one and only one settings row.

**Note**

I decided to set a default base currency for each user, thus, technically speaking, each user should have a row in `user_settings` table. This is because I intend the `user_settings` table as an extension of the base `users` table.

For new users it's easy: we create the settings row at sign-up time. For already created user instead I create their custom settings after the first log in. I'm not happy with this solution, however, specially for the "already-created users" workaround. 

Another solution would be to create user settings rows within a migration but I may be missing data (users or the id of default currency).

Do you have any better idea?